### PR TITLE
Add whitespace trimming test for renderPrompt

### DIFF
--- a/ags/agent/prompts/__tests__/prompts.test.js
+++ b/ags/agent/prompts/__tests__/prompts.test.js
@@ -21,6 +21,12 @@ describe('Prompt Utilities', () => {
             };
             expect(renderPrompt(template, variables)).toBe('Hello John! Welcome to {{place}}');
         });
+
+        it('should trim whitespace around variable names', () => {
+            const template = 'Hello {{  name  }}!';
+            const variables = { name: 'John' };
+            expect(renderPrompt(template, variables)).toBe('Hello John!');
+        });
     });
 
     describe('getPrompt', () => {


### PR DESCRIPTION
## Summary
- test whitespace trimming in `renderPrompt`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d3c33cb0c8320b0177437ee18447c